### PR TITLE
Legg til nedlasting frå F-droid, fjern «Store»

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,8 @@
 <h3>Last ned</h3>
 
 <ul>
-<li><a href="http://www.olejon.net/code/mdapp/?page=android_app"><b>Last ned fra Google Play Store</b></a></li>
+<li><a href="http://www.olejon.net/code/mdapp/?page=google_play"><b>Last ned fra Google Play</b></a></li>
+<li><a href="http://www.olejon.net/code/mdapp/?page=f-droid"><b>Last ned fra F-droid</b></a></li>
 </ul>
 
 <p>Tilbakemeldinger kan sendes til mail(at)olejon(dot)net. <a href="http://www.olejon.net/code/mdapp/?page=issues" target="_blank">Feil rapporteres her</a>.</p>


### PR DESCRIPTION
Det heiter «Google Play», ikkje «Google Play Store».
Appen er også tilgjengeleg [på F-droid](https://f-droid.org/repository/browse/?fdfilter=legeappen&fdid=net.olejon.mdapp), og sidan den er fri programvare, og f-droid er full av anna bra fri programvare tykkjer eg det hadde vore fint å promotera F-droid. Du må sjølvsagt laga til og endra namn på sidene på olejon.net (kanskje laga eit eige git-repository for dei?).